### PR TITLE
Itunes songs grid feature :  Grid, Skeleton Loads, Playable Preview songs 

### DIFF
--- a/app/components/SongCard/index.js
+++ b/app/components/SongCard/index.js
@@ -1,0 +1,120 @@
+/**
+ *
+ * MusicCard
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Card, Image, Typography, Button } from 'antd';
+import { PlayCircleTwoTone, StopTwoTone } from '@ant-design/icons';
+
+const { Paragraph, Title } = Typography;
+
+const Container = styled(Card)`
+  && {
+    max-width: 300px;
+    height: 450px;
+    background-color: #313131;
+    display: block;
+    border-radius: 16px;
+    box-shadow: inset -6px -6px 12px rgba(0, 0, 0, 0.8), inset 6px 6px 12px rgba(255, 255, 255, 0.4);
+  }
+`;
+
+const IconsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+const CommonIconStyle = {
+  fontSize: 18
+};
+
+const ControlButton = styled(Button)`
+  && {
+    color: white;
+    display: flex;
+    margin: auto 3px;
+    justify-content: space-between;
+    align-items: center;
+    background-color: transparent;
+  }
+`;
+// const CommonIconSize = 10;
+
+export function SongCard({ song }) {
+  const { shortDescription, artworkUrl100, artistName, previewUrl } = song;
+  const [play, setPlay] = React.useState(false);
+  const songElement = React.useRef(null);
+
+  const actions = {
+    PLAY: 'playMusic',
+    STOP: 'stopMusic'
+  };
+
+  const handleMusic = (action) => {
+    if (action === actions.PLAY) {
+      songElement.current.src = previewUrl;
+      setPlay(!play);
+      songElement.current.play();
+    } else if (action === actions.STOP) {
+      songElement.current.src = '';
+      setPlay(!play);
+    } else {
+      return;
+    }
+  };
+
+  return (
+    // <div data-testid="song-card">
+    <Container data-testid="song-card">
+      <Image src={artworkUrl100} width="80%" preview="false" height="250px" />
+      <Title style={{ fontSize: 18 }} italic={true}>
+        {artistName}
+      </Title>
+      <Paragraph style={{ fontSize: 12, height: '50px' }}>
+        {shortDescription ? shortDescription : 'No Description available'}
+      </Paragraph>
+      <IconsContainer>
+        <ControlButton
+          onClick={() => handleMusic(actions.PLAY)}
+          disabled={play ? true : false}
+          type={play ? 'text' : 'ghost'}
+          icon={<PlayCircleTwoTone style={CommonIconStyle} />}
+        >
+          Play
+        </ControlButton>
+        {/* <ControlButton
+          type="ghost"
+          onClick={() => handleMusic(actions.PAUSE)}
+          disabled={play ? false : true}
+          icon={<PauseCircleTwoTone style={CommonIconStyle} />}
+          size="large"
+}
+        >
+          Pause
+        </ControlButton> */}
+        <ControlButton
+          disabled={play ? false : true}
+          onClick={() => handleMusic(actions.STOP)}
+          type={play ? 'ghost' : 'text'}
+          icon={<StopTwoTone style={CommonIconStyle} />}
+          size="large"
+        >
+          Stop
+        </ControlButton>
+      </IconsContainer>
+      <audio ref={songElement}></audio>
+    </Container>
+    // </div>
+  );
+}
+
+SongCard.propTypes = {
+  song: PropTypes.object
+};
+export default SongCard;

--- a/app/components/SongCard/tests/__snapshots__/index.test.js.snap
+++ b/app/components/SongCard/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,145 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SongCard/> tests should render and match the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="ant-card ant-card-bordered SongCard__Container-sc-163fh4j-0 bgYNxs"
+      data-testid="song-card"
+    >
+      <div
+        class="ant-card-body"
+      >
+        <div
+          class="ant-image"
+          style="width: 80%; height: 250px;"
+        >
+          <img
+            class="ant-image-img"
+            src="https://www.google.com/url?sa=i&url=https%3A%2F%2Fdribbble.com%2Fshots%2F14395014-Music-Logo&psig=AOvVaw3I_T0J8_ZRKW_g4VF_KmKz&ust=1630933127025000&source=images&cd=vfe&ved=2ahUKEwiT5uO-8efyAhWVHLcAHVSbCvQQjRx6BAgAEAk"
+            style="height: 250px;"
+          />
+          <div
+            class="ant-image-mask"
+          >
+            <div
+              class="ant-image-mask-info"
+            >
+              <span
+                aria-label="eye"
+                class="anticon anticon-eye"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="eye"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+                  />
+                </svg>
+              </span>
+              Preview
+            </div>
+          </div>
+        </div>
+        <h1
+          class="ant-typography"
+          style="font-size: 18px;"
+        >
+          <i>
+            Artist Name
+          </i>
+        </h1>
+        <div
+          class="ant-typography"
+          style="font-size: 12px; height: 50px;"
+        >
+          Song Description
+        </div>
+        <div
+          class="SongCard__IconsContainer-sc-163fh4j-1 fJrksM"
+        >
+          <button
+            class="ant-btn ant-btn-ghost SongCard__ControlButton-sc-163fh4j-2 dcxDWV"
+            type="button"
+          >
+            <span
+              aria-label="play-circle"
+              class="anticon anticon-play-circle"
+              role="img"
+              style="font-size: 18px;"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="play-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                  fill="#1890ff"
+                />
+                <path
+                  d="M512 140c-205.4 0-372 166.6-372 372s166.6 372 372 372 372-166.6 372-372-166.6-372-372-372zm164.1 378.2L457.7 677.1a8.02 8.02 0 01-12.7-6.5V353a8 8 0 0112.7-6.5l218.4 158.8a7.9 7.9 0 010 12.9z"
+                  fill="#e6f7ff"
+                />
+                <path
+                  d="M676.1 505.3L457.7 346.5A8 8 0 00445 353v317.6a8.02 8.02 0 0012.7 6.5l218.4-158.9a7.9 7.9 0 000-12.9z"
+                  fill="#1890ff"
+                />
+              </svg>
+            </span>
+            <span>
+              Play
+            </span>
+          </button>
+          <button
+            class="ant-btn ant-btn-text ant-btn-lg SongCard__ControlButton-sc-163fh4j-2 dcxDWV"
+            disabled=""
+            type="button"
+          >
+            <span
+              aria-label="stop"
+              class="anticon anticon-stop"
+              role="img"
+              style="font-size: 18px;"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="stop"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm288.5 682.8L277.7 224C258 240 240 258 224 277.7l522.8 522.8C682.8 852.7 601 884 512 884c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372c0 89-31.3 170.8-83.5 234.8z"
+                  fill="#1890ff"
+                />
+                <path
+                  d="M512 140c-205.4 0-372 166.6-372 372s166.6 372 372 372c89 0 170.8-31.3 234.8-83.5L224 277.7c16-19.7 34-37.7 53.7-53.7l522.8 522.8C852.7 682.8 884 601 884 512c0-205.4-166.6-372-372-372z"
+                  fill="#e6f7ff"
+                />
+              </svg>
+            </span>
+            <span>
+              Stop
+            </span>
+          </button>
+        </div>
+        <audio />
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/app/components/SongCard/tests/index.test.js
+++ b/app/components/SongCard/tests/index.test.js
@@ -1,0 +1,30 @@
+/**
+ *
+ * Tests for MusicCard
+ *
+ */
+
+import React from 'react';
+// import { fireEvent } from '@testing-library/dom'
+import { renderWithIntl } from '@utils/testUtils';
+import SongCard from '../index';
+
+describe('<SongCard/> tests', () => {
+  const song = {
+    shortDescription: 'Song Description',
+    artworkUrl100:
+      'https://www.google.com/url?sa=i&url=https%3A%2F%2Fdribbble.com%2Fshots%2F14395014-Music-Logo&psig=AOvVaw3I_T0J8_ZRKW_g4VF_KmKz&ust=1630933127025000&source=images&cd=vfe&ved=2ahUKEwiT5uO-8efyAhWVHLcAHVSbCvQQjRx6BAgAEAk',
+    artistName: 'Artist Name',
+    previewUrl: 'https://mockurl.com'
+  };
+
+  it('should render and match the snapshot', () => {
+    const { baseElement } = renderWithIntl(<SongCard song={song} />);
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should contain 1 SongCard component', () => {
+    const { getAllByTestId } = renderWithIntl(<SongCard song={song} />);
+    expect(getAllByTestId('song-card').length).toBe(1);
+  });
+});

--- a/app/containers/ItunesContainer/index.js
+++ b/app/containers/ItunesContainer/index.js
@@ -6,7 +6,7 @@ import { compose } from 'redux';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
-import { Card, Input } from 'antd';
+import { Card, Skeleton, Input } from 'antd';
 import styled from 'styled-components';
 import { injectIntl } from 'react-intl';
 import T from '@components/T';
@@ -14,6 +14,7 @@ import { injectSaga } from 'redux-injectors';
 import { selectItunesContainer, selectGridData, selectSearchError, selectSearchTerm } from './selectors';
 import { itunesContainerCreators } from './reducer';
 import itunesContainerSaga from './saga';
+import SongCard from '@app/components/SongCard';
 
 const { Search } = Input;
 
@@ -35,6 +36,22 @@ const Container = styled.div`
     margin: 0 auto;
     padding: ${(props) => props.padding}px;
   }
+`;
+
+const ResultContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: ${(props) => props.maxwidth * 2}px;
+  width: 90%;
+  margin: 10px auto;
+  padding: ${(props) => props.padding}px;
+`;
+
+const MusicGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-column-gap: 20;
+  grid-row-gap: 30px;
 `;
 
 export function ItunesContainer({
@@ -73,19 +90,67 @@ export function ItunesContainer({
   };
   const debouncedHandleOnChange = debounce(handleOnChange, 200);
 
+  const renderGridData = () => {
+    const songs = get(gridData, 'results', []);
+    const totalCount = get(gridData, 'resultCount', 0);
+    return (
+      (songs.length !== 0 || loading) && (
+        <Skeleton loading={loading} active>
+          {searchTerm && (
+            <div>
+              <T id="search_query" values={{ searchTerm }} />
+            </div>
+          )}
+          {totalCount !== 0 && (
+            <div>
+              <T id="matching_songs" values={{ totalCount }} />
+            </div>
+          )}
+          <MusicGrid>
+            {songs.map((song, index) => {
+              return <SongCard song={song} key={index} />;
+            })}
+          </MusicGrid>
+        </Skeleton>
+      )
+    );
+  };
+
+  const renderDefaultOrErrorState = () => {
+    let search_error;
+    if (searchError) {
+      search_error = searchError;
+    } else if (!get(gridData, 'totalCount', 0)) {
+      search_error = 'search_songs_default';
+    }
+    return (
+      !loading &&
+      search_error && (
+        <CustomCard color={searchError ? 'red' : 'grey'} title={intl.formatMessage({ id: 'list_songs' })}>
+          <T id={search_error} />
+        </CustomCard>
+      )
+    );
+  };
+
   return (
-    <Container maxwidth={maxwidth} padding={padding}>
-      <CustomCard title={intl.formatMessage({ id: 'songs_search' })} maxwidth={maxwidth}>
-        <T marginBottom={10} id="search_your_songs" />
-        <Search
-          data-testid="search-bar"
-          defaultValue={searchTerm}
-          type="text"
-          onChange={(evt) => debouncedHandleOnChange(evt.target.value)}
-        />
-      </CustomCard>
-      <div> {loading ? 'Loading ...' : 'Loaded ...'} </div>
-    </Container>
+    <>
+      <Container maxwidth={maxwidth} padding={padding}>
+        <CustomCard title={intl.formatMessage({ id: 'songs_search' })} maxwidth={maxwidth}>
+          <T marginBottom={10} id="search_your_songs" />
+          <Search
+            data-testid="search-bar"
+            defaultValue={searchTerm}
+            type="text"
+            onChange={(evt) => debouncedHandleOnChange(evt.target.value)}
+          />
+        </CustomCard>
+      </Container>
+      <ResultContainer>
+        {renderGridData()}
+        {renderDefaultOrErrorState()}
+      </ResultContainer>
+    </>
   );
 }
 

--- a/app/containers/ItunesContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/ItunesContainer/tests/__snapshots__/index.test.js.snap
@@ -76,10 +76,37 @@ exports[`ItunesContainer Tests should render and match to the snapshot 1`] = `
           </span>
         </div>
       </div>
-      <div>
-         
-        Loaded ...
-         
+    </div>
+    <div
+      class="ItunesContainer__ResultContainer-rg528l-2 iJdqZx"
+    >
+      <div
+        class="ant-card ant-card-bordered ItunesContainer__CustomCard-rg528l-0 jzArEu"
+        color="grey"
+      >
+        <div
+          class="ant-card-head"
+        >
+          <div
+            class="ant-card-head-wrapper"
+          >
+            <div
+              class="ant-card-head-title"
+            >
+              List of songs will appear below
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-card-body"
+        >
+          <p
+            class="T__StyledText-gjlic1-0 kYcyRq"
+            data-testid="t"
+          >
+            search_songs_default
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/containers/ItunesContainer/tests/index.test.js
+++ b/app/containers/ItunesContainer/tests/index.test.js
@@ -47,23 +47,4 @@ describe('ItunesContainer Tests', () => {
     await timeout(500);
     expect(mockDispatchSearch).toBeCalled();
   });
-
-  it('should update the loading state and render "Loading ..." when calling to api', async () => {
-    const { getByText, getByTestId } = renderProvider(<ItunesContainer dispatchSearchSongs={mockDispatchSearch} />);
-
-    fireEvent.change(getByTestId('search-bar'), {
-      target: { value: 'Tayl' }
-    });
-    await timeout(500);
-    expect(getByText('Loading ...'));
-  });
-
-  it('should update the loading state and render "Loaded ..." when gridData is available', () => {
-    const gridData = {
-      resultCount: 50,
-      results: [{ songName: 'Song1' }, { songName: 'Song2' }]
-    };
-    const { getByText } = renderProvider(<ItunesContainer gridData={gridData} />);
-    expect(getByText('Loaded ...'));
-  });
 });

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -2,7 +2,7 @@
   "itunes_header": "My iTunes Store!",
   "songs_search": "My iTunes Store",
   "list_songs": "List of songs will appear below",
-  "seach_songs_default": "Enter the song name you want to listen right now ...",
+  "search_songs_default": "Enter the song name you want to listen right now ...",
   "search_your_songs": "Search your songs ...",
   "search_query": "Search query: {searchTerm}",
   "matching_songs": "Number of Songs found: {totalCount}",


### PR DESCRIPTION
### Ticket Link


### Related Links

---

### Description
This is the Second PR for the Itunes Music Store app. 
The new changes are :
- List of songs displayed from search results in form of Grid
- Each song has their own Card 
- Play / Stop songs
- Ant design used extensively for Music Card Component and music control Icons
- Unit tests for each

### Steps to Reproduce / Test
- yarn test

### GIF's
- Search Results Displayed in form of Grid with song's preview playable.
![PR2SearchGrid](https://user-images.githubusercontent.com/89903914/132294479-adb141a8-68c4-442d-8b7e-9577dbd87fa8.gif)




- Output of yarn test
![PR2Yarntest](https://user-images.githubusercontent.com/89903914/132291319-c4bc9979-0cdb-44b1-8ba4-f010e529518e.gif)



